### PR TITLE
Disable on press escape key

### DIFF
--- a/src/content_script.js
+++ b/src/content_script.js
@@ -17,7 +17,7 @@ browser.runtime.onMessage.addListener(message => {
 });
 
 window.addEventListener(
-  'keypress',
+  'keydown',
   e => {
     if (e.key === 'Escape' && Overlay.isActive) {
       Overlay.current.close();


### PR DESCRIPTION
## Why

It can't disable on press escape key since Firefox 65.

## What

Changed event type `keypress` → `keydown` .