### PR TITLE
Fallback to copy in chrome

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -48,7 +48,16 @@ browser.runtime.onMessage.addListener((message, sender) => {
       browser.tabs.create({ url: message.url });
       break;
     case 'copy':
-      navigator.clipboard.writeText(message.text);
+      navigator.clipboard.writeText(message.text).catch((e) => {
+        console.warn('failed navigator.clipboard.writeText', e);
+        const input = document.createElement('textarea');
+        document.body.appendChild(input);
+        input.value = message.text;
+        input.focus();
+        input.select();
+        document.execCommand('Copy');
+        input.remove();
+      });
       break;
   }
 });


### PR DESCRIPTION
## Why

`navigator.clipboard.writeText` is failed in Google Chrome.

## What

Fallback to `document.execCommand('Copy')` on fail.