### PR TITLE
Do not inherit background

### DIFF
--- a/stylesheets/overlay.css
+++ b/stylesheets/overlay.css
@@ -9,6 +9,7 @@
   height: 100%;
   display: block;
   z-index: 2147483647;
+  background: transparent;
 }
 
 .--anchor-selector-overlay > svg > .background > path {


### PR DESCRIPTION
## Why

https://www.openssl.org/
![image](https://user-images.githubusercontent.com/6045753/101197134-0ec18780-36a5-11eb-9395-0b1bd1997142.png)

## What

overwrite the background style not to inherit from the parent element.