### PR TITLE
Set homepage_url

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "name": "Anchor Selector",
   "version": "0.8.6",
   "description": "Select link anchor element",
+  "homepage_url": "https://github.com/bgpat/anchor-selector",
   "applications": {
     "gecko": {
       "id": "{22a2fd71-5ac1-46c9-88e8-fe65a41bad62}",


### PR DESCRIPTION
fix #803 

> Also it would be great if you added the github repository to the Firefox extension page. A closed-source extension asking for full site permissions is a bit uncomfortable. I only found this repo by downloading the extension, opening it up, and noticing the repo mentioned in the embedded readme file.

![image](https://github.com/bgpat/anchor-selector/assets/6045753/24781763-aa32-4cc2-a050-f9f9e3775eda)
